### PR TITLE
Add name to all tasks

### DIFF
--- a/public/app/services/simulation.ts
+++ b/public/app/services/simulation.ts
@@ -282,7 +282,10 @@ module App {
                 this.$log.info('visualizing ' + name + ' at: ' + url);
 
                 // Make sure the layer group exists
-                let groupId = task.input.ensemble + '_' + task.input.simulation;
+                let ensamble = task.input.ensamble || 'dynamic';
+                let simulation = task.input.simulation || 'simulation';
+                let groupId = ensamble + '_' + simulation;
+
                 let group = this.layerService.findGroupById(groupId);
                 if (group === null) {
                     let title = task.input.ensemble + ': ' + task.input.simulation;
@@ -358,7 +361,10 @@ module App {
                     let key = formItem.key;
                     let layerId = 'input-' + task._id + '-' + key;
 
-                    let groupId = task.input.ensemble + '_' + task.input.simulation;
+                    let ensamble = task.input.ensamble || 'dynamic';
+                    let simulation = task.input.simulation || 'simulation';
+                    let groupId = ensamble + '_' + simulation;
+
                     let group = this.layerService.findGroupById(groupId);
                     if (group === null) {
                         let title = task.input.ensemble + ': ' + task.input.simulation;

--- a/public/app/simform/simform.directive.ts
+++ b/public/app/simform/simform.directive.ts
@@ -108,12 +108,8 @@ module App {
             }
 
             // Initialize the simulation form
-            this.schema = {};
-            this.form = [];
-            this.model = {};
-            this.featureSubscriptions = [];
+            this.resetForm();
             this.formLayers = [];
-            this.legend = "";
 
             // Initialize custom type mapping BEFORE getting
             // the simulation form
@@ -187,9 +183,11 @@ module App {
          * Reset the simulation form
          */
         private resetForm(): void {
-            this.featureSubscriptions.forEach(handle => {
-                this.messageBusService.unsubscribe(handle);
-            });
+            try {
+              this.featureSubscriptions.forEach(handle => {
+                  this.messageBusService.unsubscribe(handle);
+              });
+            } catch(e) { }
             this.featureSubscriptions = [];
             this.form = [];
             this.schema = {};
@@ -207,6 +205,13 @@ module App {
                         this.schema = data.schema;
                         this.form = data.form;
                         this.legend = data.schema.title;
+
+                        this.form.unshift('name'); // Push at the beginning
+                        this.schema.properties['name'] = {
+                          "type": "string",
+                          "default": this.SimAdminService.simulationName,
+                          "title": "Identifier"
+                        };
 
                         this.$scope.$broadcast('schemaFormValidate');
                     } else {

--- a/public/app/simlist/simlist.directive.html
+++ b/public/app/simlist/simlist.directive.html
@@ -7,7 +7,7 @@
             </div>
 
             <button class="layer-action" ng-click="vm.toggleSimulationForm()">
-                <span class="fa fa-plus layer-action-icon"></span>{{show ? 'Show' : 'Hide'}} Simulation Form
+                <span class="fa fa-plus layer-action-icon"></span>{{show ? 'Show' : 'Hide'}} Dynamic Layer Input Form
             </button>
         </div>
 

--- a/public/app/simlist/simlist.directive.ts
+++ b/public/app/simlist/simlist.directive.ts
@@ -97,10 +97,11 @@ module App {
                     this.tasks = response.data.rows.map(el => el.value);
                     var start: TaskEnsemble = {};
                     this.tasksByEnsemble = response.data.rows.reduce(function (ensembles, cur, index): TaskEnsemble {
-                        if (!ensembles.hasOwnProperty(cur.value['input']['ensemble'])) {
-                            ensembles[cur.value['input']['ensemble']] = [];
+                        var taskName = cur.value.input.ensemble || cur.value.input.name;
+                        if (!ensembles.hasOwnProperty(taskName)) {
+                            ensembles[taskName] = [];
                         }
-                        ensembles[cur.value['input']['ensemble']].push(cur.value);
+                        ensembles[taskName].push(cur.value);
                         return ensembles;
                     }, start);
                     if (this.status) {


### PR DESCRIPTION
At the moment, tasks get an id generated by concatenating `ensamble` & `simulation` -- but `ensamble` & `simulation` do not always make sense. 

I would suggest to add an identifying label (let's call it `name`), which gets added to the task. And I would also suggest to add it to every task automatically (without having to explicitly define `name` in the json file defining the simulation schema). This pull request implements those changes. 

However, if accepted, sim-city-webservice would also need to be adjusted to auto-add `name` to the schema. More add the following lines [here](https://github.com/indodutch/sim-city-webservice/blob/develop/scripts/app.py#L124):

```
sim['form'].append('name')
sim['properties']['name'] = { "type": "string" }
```